### PR TITLE
Make the output of the product below the 'code stream' unambiguous (bsc#1057788)

### DIFF
--- a/zypper-lifecycle
+++ b/zypper-lifecycle
@@ -274,7 +274,7 @@ module SUSE
           printf(ProductFormatStr, "Codestream: " + p[:xmlfwd_codestream_name], eol_string(p[:codestream_endoflife_time_t], vendor))
           @printed_codestream = p[:xmlfwd_codestream_name]
         end
-        printf(ProductFormatStr, "    " + p[:summary], eol_string(p[:endoflife_time_t], vendor))
+        printf(ProductFormatStr, "    Product: " + p[:summary], eol_string(p[:endoflife_time_t], vendor))
       else
         printf(ProductFormatStr, p[:summary], eol_string(p[:endoflife_time_t], vendor))
         @printed_codestream = nil


### PR DESCRIPTION
This should make it more obvious what is the general codestream EOL and what
relates to service packs - or how it is called properly - "products".

![screenshot_sle15_2018-03-21_15 49 16](https://user-images.githubusercontent.com/1693432/37718294-a952a476-2d22-11e8-9ff7-0c38a1b69541.png) shows the output from a local run after hot-patching the code on a VM